### PR TITLE
docker-composeでwarningが出ていたので修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   dbt:
     build: .


### PR DESCRIPTION
下記のwarningが出ていた
```
WARN[0000] /Users/hogehoge/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```